### PR TITLE
Update vote descendant check

### DIFF
--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -267,7 +267,9 @@ impl HeaviestSubtreeForkChoice {
                 let slot_hash_key = (slot, bank.hash());
 
                 // Skip if we've already voted on this fork
-                if latest_validator_votes_for_frozen_banks.has_voted_for_this_or_descendant(slot) {
+                if latest_validator_votes_for_frozen_banks
+                    .has_voted_for_this_or_descendant(slot, &*bank_forks_r)
+                {
                     continue;
                 }
 


### PR DESCRIPTION
## Summary
- broaden vote descendant search in `LatestValidatorVotesForFrozenBanks`
- pass `BankForks` to check for backfill misses

## Testing
- `cargo fmt --all` *(fails: could not download rust toolchain)*
- `cargo test -p solana-core --lib --no-run` *(fails: could not download rust toolchain)*

------
https://chatgpt.com/codex/tasks/task_e_6851843b1f3c8332b924d4ca75b78247