### PR TITLE
Fix vote lookup iteration

### DIFF
--- a/core/src/consensus/heaviest_subtree_fork_choice.rs
+++ b/core/src/consensus/heaviest_subtree_fork_choice.rs
@@ -338,13 +338,6 @@ impl HeaviestSubtreeForkChoice {
                 );
 
                 // Update tower with new votes
-                //tower.record_vote(last_slot, last_hash);
-                // tower.record_bank_vote_and_update_lockouts(
-                //     last_slot,
-                //     last_hash,
-                //     true,
-                //     Hash::default(),
-                // );
                 if let Some(vote_bank) = bank_forks_r.get(last_slot) {
                     // Get block_id using the same approach as record_bank_vote
                     let block_id = vote_bank.block_id().unwrap_or_else(|| Hash::default());

--- a/core/src/consensus/latest_validator_votes_for_frozen_banks.rs
+++ b/core/src/consensus/latest_validator_votes_for_frozen_banks.rs
@@ -37,13 +37,13 @@ impl LatestValidatorVotesForFrozenBanks {
             false
         };
 
-        for &(_pk, (vote_slot, _)) in self.max_gossip_frozen_votes.values() {
+        for (_, &(vote_slot, _)) in self.max_gossip_frozen_votes.iter() {
             if check_vote(vote_slot) {
                 return true;
             }
         }
 
-        for &(_pk, (vote_slot, _)) in self.max_replay_frozen_votes.values() {
+        for (_, &(vote_slot, _)) in self.max_replay_frozen_votes.iter() {
             if check_vote(vote_slot) {
                 return true;
             }


### PR DESCRIPTION
## Summary
- fix iteration pattern in `has_voted_for_this_or_descendant`

## Testing
- `cargo test -p solana-core test_process_missed_votes_backfills_slots -- --nocapture` *(fails: could not download file)*

------
https://chatgpt.com/codex/tasks/task_e_685186787c208332bf5ed879f7617d55