### PR TITLE
Fix visibility for latest_vote

### DIFF
--- a/core/src/consensus/latest_validator_votes_for_frozen_banks.rs
+++ b/core/src/consensus/latest_validator_votes_for_frozen_banks.rs
@@ -145,7 +145,7 @@ impl LatestValidatorVotesForFrozenBanks {
     }
 
     #[cfg(test)]
-    fn latest_vote(&self, pubkey: &Pubkey, is_replay_vote: bool) -> Option<&(Slot, Vec<Hash>)> {
+    pub fn latest_vote(&self, pubkey: &Pubkey, is_replay_vote: bool) -> Option<&(Slot, Vec<Hash>)> {
         let vote_map = if is_replay_vote {
             &self.max_replay_frozen_votes
         } else {


### PR DESCRIPTION
## Summary
- expose `latest_vote` function for tests by making it public

## Testing
- `cargo check` *(fails: network access issue)*

------
https://chatgpt.com/codex/tasks/task_e_68519248015483328591b7ca4b08f580